### PR TITLE
INTERLOK-3298 Fix snyk vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,11 @@ ext {
   componentName = "Interlok Artifact Downloader"
   organizationName = "Adaptris Ltd"
   organizationUrl = "https://www.adaptris.com"
+  springVersion = "5.2.6.RELEASE"
   slf4jVersion = "1.7.30"
   log4j2Version = "2.13.3"
   springBootVersion = "2.3.0.RELEASE"
+  hibernateValidatorVersion = "6.1.5.Final"
   jacksonVersion = "2.11.0"
   jacksonDatabindVersion = "2.11.0"
   swaggerVersion = "2.1.2"
@@ -91,6 +93,20 @@ dependencies {
   compile "org.springframework.boot:spring-boot-starter-log4j2:$springBootVersion"
   compile("org.springframework.boot:spring-boot-starter-thymeleaf:$springBootVersion")
   compile "org.springframework.boot:spring-boot-starter-jersey:$springBootVersion"
+  constraints {
+    compile("org.springframework:spring-web:$springVersion") {
+      because "Previous versions have a bug impacting this application (CVE-2020-5398)"
+    }
+    compile("org.hibernate.validator:hibernate-validator:$hibernateValidatorVersion") {
+      because "Previous versions have a bug impacting this application (CVE-2020-10693)"
+    }
+    compile("com.fasterxml.jackson.core:jackson-data-bind:$jacksonDatabindVersion") {
+      because "Previous versions have a bug impacting this application"
+    }
+    compile("org.apache.tomcat.embed:tomcat-embed-core:9.0.35") {
+      because "Previous versions have a bug impacting this application (CVE-2020-9484)"
+    }
+  }
 
   compile "com.google.guava:guava:29.0-jre"
 
@@ -101,15 +117,7 @@ dependencies {
   compile "org.apache.logging.log4j:log4j-jul:$log4j2Version"
   compile "org.apache.logging.log4j:log4j-slf4j-impl:$log4j2Version"
   compile "org.apache.logging.log4j:log4j-api:$log4j2Version"
-
-  compile "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
-  compile "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
-  compile "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
-  compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
-  compile "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:$jacksonVersion"
-  compile "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:$jacksonVersion"
-  compile "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:$jacksonVersion"
-
+  
   compile "io.swagger.core.v3:swagger-core:$swaggerVersion"
   compile "io.swagger.core.v3:swagger-jaxrs2:$swaggerVersion"
 


### PR DESCRIPTION
## Motivation

Snyk is reporting some issues: https://app.snyk.io/org/adaptris/project/60842682-4fac-4e03-bb95-4365c60a66c0/history/5166d8f1-89dc-49ac-8e79-89ccb04bedb4

However we should not really need that as locally the build does not depends on impacted dependency versions.

## Modification

Use gradle constrain to override some dependency versions.

## Result

The vulnerabilities should not be reported in Snyk

## Testing

Start the webapp and it should work.
Snyk should not reported any issue.
