### PR TITLE
INTERLOK-3402 Upgrade jersey to 2.31

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'application'
   id 'jacoco'
   id 'eclipse'
-  id 'org.springframework.boot' version '2.3.2.RELEASE'
+  id 'org.springframework.boot' version '2.3.3.RELEASE'
   id 'io.spring.dependency-management' version '1.0.9.RELEASE'
   id 'com.github.spotbugs' version '4.5.0'
   id "org.owasp.dependencycheck" version "5.3.2.1"
@@ -24,6 +24,9 @@ ext {
   ivyVersion = "2.5.0"
   mockitoVersion = "3.4.6"
 }
+
+// Override spring boot dependencies versions
+ext["jersey.version"] = "2.31"
 
 run.enabled = false
 distTar.enabled=false


### PR DESCRIPTION
## Motivation

Snyk reported a vulnerability: XML Entity Expansion

## Modification

Upgrade jersey to 2.31
Also upgrade spring boot to 2.3.3

## Result

The vulnerability is fixed

## Testing

The webapp is running.
Snyk does not report the vulnerability anymore
