### PR TITLE
fixes apache commons and swagger vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'application'
   id 'jacoco'
   id 'eclipse'
-  id "org.owasp.dependencycheck" version "8.2.1"
+  id "org.owasp.dependencycheck" version "12.1.1"
   id 'com.github.spotbugs' version '5.2.5'
   id 'io.spring.dependency-management' version '1.1.7'
   id 'org.springframework.boot' version '2.7.18'
@@ -17,7 +17,7 @@ ext {
   componentName = "Interlok Artifact Downloader"
   organizationName = "Adaptris Ltd"
   organizationUrl = "https://www.adaptris.com"
-  swaggerVersion = "2.2.27"
+  swaggerVersion = "2.2.35"
   ivyVersion = "2.5.3"
   jacksonBomVersion = "2.18.2"
 }
@@ -96,7 +96,7 @@ dependencies {
   implementation "io.swagger.core.v3:swagger-core:$swaggerVersion"
   implementation "io.swagger.core.v3:swagger-jaxrs2:$swaggerVersion"
 
-  implementation "org.apache.commons:commons-lang3:3.17.0"
+  implementation "org.apache.commons:commons-lang3:3.18.0"
   implementation "commons-io:commons-io:2.18.0"
 
   implementation "org.apache.ivy:ivy:$ivyVersion"


### PR DESCRIPTION
## Motivation

Fixing High Vulnerabilities ready for release. These vulnerabilites have been flagged by Snyk.

## Modification

Minor upgrades to Apache Commons and Swagger as well as the owasp dependencycheck

## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

No user or testing impact.
